### PR TITLE
Only backup resources with label velero-backup="true"

### DIFF
--- a/storage/prod-pvc-onboarding.yaml
+++ b/storage/prod-pvc-onboarding.yaml
@@ -5,6 +5,10 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: onboarding
+  labels:
+    # Backup this PersistentVolumeClaim, we can't regenerate
+    # its data from scratch.
+    velero-backup: "true"
 spec:
   accessModes:
   - ReadWriteOnce

--- a/system/common-velero-backup.yaml
+++ b/system/common-velero-backup.yaml
@@ -38,10 +38,9 @@ spec:
     # cluster-scoped) would also be backed up.
     includeClusterResources: null
     # Individual objects must match this label selector to be included in the scheduled backup. Optional.
-    # labelSelector:
-    #   matchLabels:
-    #     app: velero
-    #     component: server
+    labelSelector:
+      matchLabels:
+        velero-backup: "true"
     # Whether or not to snapshot volumes. This only applies to PersistentVolumes for Azure, GCE, and
     # AWS. Valid values are true, false, and null/unset. If unset, Velero performs snapshots as long as
     # a persistent volume provider is configured for Velero.


### PR DESCRIPTION
Backup resources explicitly marked with velero-backup="true" to keep
the backup cost down.
The majority of our resources should be stateless anyway.