### PR TITLE
Use Recreate deploy strategy for onboarding

### DIFF
--- a/onboarding/templates/deployment.yaml
+++ b/onboarding/templates/deployment.yaml
@@ -15,10 +15,7 @@ spec:
   {{- if .Values.onboarding.strategy }}
   {{- with .Values.onboarding.strategy }}
   strategy:
-    type: {{ toYaml .type }}
-    rollingUpdate:
-      maxUnavailable: {{ toYaml .rollingUpdate.maxUnavailable }}
-      maxSurge: {{ toYaml .rollingUpdate.maxSurge }}
+    type: Recreate
   {{- end }}
   {{- end }}
   revisionHistoryLimit: {{ .Values.onboarding.revisionHistoryLimit }}


### PR DESCRIPTION
RollingUpdate waits forever on the ReadWriteOnce PVC to get available, which
it won't becase the old onboarding pod is using it.

Use Recreate for now, but maybe StatefulSets would be the better option.