### PR TITLE
fix: don't use wait-for-it to start the crawler

### DIFF
--- a/crawler/templates/cronjob.yaml
+++ b/crawler/templates/cronjob.yaml
@@ -23,8 +23,7 @@ spec:
             image: "{{ .Values.global.registry }}{{ .Values.crawler.images.crawler.repository }}:{{ tpl .Values.crawler.images.crawler.tag . }}"
             imagePullPolicy: {{ .Values.crawler.images.crawler.pullPolicy }}
 
-            command: ["./wait-for-it.sh"]
-            args: ["$(ELASTIC_URL)", "-t", "300", "--", "./start.sh"]
+            command: ["./start.sh"]
 
             volumeMounts:
             - name: configs


### PR DESCRIPTION
For some reason, using args results in an error:
"args does not match original args defined by env-injector
application=env-injector component=akv2k8s".

Maybe it's because of the environment variable that holds
different values at different stages of the deploy?

Anyway, we don't strictly need wait-for-it because Elasticsearch
is supposed to be up and we are ok to fail if it happens to be down.