### PR TITLE
feat: deploy onboarding with Keel

### DIFF
--- a/onboarding/templates/deployment.yaml
+++ b/onboarding/templates/deployment.yaml
@@ -10,6 +10,27 @@ metadata:
     chart: {{ template "onboarding.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    timestamp: "{{ date "20060102150405" .Release.Time }}"
+
+    # Keel will automatically update this Deployment when a new Docker image
+    # is pushed to DockerHub.
+    keel.sh/trigger: poll
+    keel.sh/pollSchedule: "@every 1m"
+
+    {{- if eq (default "production" .Values.onboarding.deployEnvironment) "staging" }}
+    {{- /*
+    When in staging, update when the same image tag (master) is pushed
+    */}}
+    keel.sh/policy: force
+    keel.sh/match-tag: "true"
+    {{- else }}
+    {{- /*
+    When in production, update on new semver tag
+    */}}
+    keel.sh/policy: patch
+    {{- end }}
+
 spec:
   replicas: {{ .Values.onboarding.replicaCount }}
   {{- if .Values.onboarding.strategy }}

--- a/onboarding/values-staging.yaml
+++ b/onboarding/values-staging.yaml
@@ -8,7 +8,7 @@ onboarding:
 
   images:
     repository: docker.io/italia/developers-italia-onboarding
-    tag: latest
+    tag: master
     pullPolicy: Always
 
   deployEnvironment: "staging"

--- a/onboarding/values.yaml
+++ b/onboarding/values.yaml
@@ -8,7 +8,7 @@ onboarding:
 
   images:
     repository: docker.io/italia/developers-italia-onboarding
-    tag: latest
+    tag: v1.3.1
     pullPolicy: Always
 
   env:


### PR DESCRIPTION
Configure Keel so that pushes to the Docker image
italia/developers-italia-onboarding:master
will update the staging deployment and pushes to
italia/developers-italia-onboarding:v*.*.* will update the production
one.