### PR TITLE
feat: add CORS headers to crawler.developers.italia.it

### DIFF
--- a/crawler/values.yaml
+++ b/crawler/values.yaml
@@ -11,7 +11,7 @@ crawler:
       pullPolicy: Always
     nginx:
       repository: docker.io/nginx
-      tag: 1.17.3-alpine
+      tag: 1.20.0-alpine
       pullPolicy: IfNotPresent
 
   env:
@@ -39,6 +39,8 @@ crawler:
       kubernetes.io/ingress.class: nginx
       kubernetes.io/tls-acme: "true"
       nginx.ingress.kubernetes.io/ssl-redirect: "true"
+      nginx.ingress.kubernetes.io/enable-cors: "true"
+      nginx.ingress.kubernetes.io/cors-allow-methods: "GET, OPTIONS"
       cert-manager.io/cluster-issuer: letsencrypt-prod
       cert-manager.io/acme-challenge-type: http01
     path: /


### PR DESCRIPTION
Add CORS headers to be able to GET the crawler JSON log files
(https://crawler.developers.italia.it/$hosting/$org/$repo/log.json)
from https://developers.italia.it.

Also bump nginx version.