### PR TITLE
feat: add redirect for stato-migrazione.anpr.it

### DIFF
--- a/redirects-stato-migrazione-anpr-it/.helmignore
+++ b/redirects-stato-migrazione-anpr-it/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/redirects-stato-migrazione-anpr-it/Chart.yaml
+++ b/redirects-stato-migrazione-anpr-it/Chart.yaml
@@ -1,0 +1,8 @@
+---
+
+apiVersion: v1
+
+name: redirects-stato-migrazione-anpr-it
+description: Nginx performing redirect for stato-migrazione.anpr.it
+
+version: 0.1.0

--- a/redirects-stato-migrazione-anpr-it/templates/_helpers.tpl
+++ b/redirects-stato-migrazione-anpr-it/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "redirects-stato-migrazione-anpr-it.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "redirects-stato-migrazione-anpr-it.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "redirects-stato-migrazione-anpr-it.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/redirects-stato-migrazione-anpr-it/templates/configmap.yaml
+++ b/redirects-stato-migrazione-anpr-it/templates/configmap.yaml
@@ -1,0 +1,13 @@
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "redirects-stato-migrazione-anpr-it.fullname" . }}-nginx-configmap
+  labels:
+    app: {{ template "redirects-stato-migrazione-anpr-it.name" . }}
+    chart: {{ template "redirects-stato-migrazione-anpr-it.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  cloud_italia_it.conf: {{ toYaml .Values.redirects_stato_migrazione_anpr_it.nginx_config | indent 4 }}

--- a/redirects-stato-migrazione-anpr-it/templates/deployment.yaml
+++ b/redirects-stato-migrazione-anpr-it/templates/deployment.yaml
@@ -1,0 +1,59 @@
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "redirects-stato-migrazione-anpr-it.fullname" . }}-nginx
+  labels:
+    app: {{ template "redirects-stato-migrazione-anpr-it.name" . }}
+    chart: {{ template "redirects-stato-migrazione-anpr-it.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.redirects_stato_migrazione_anpr_it.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "redirects-stato-migrazione-anpr-it.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "redirects-stato-migrazione-anpr-it.name" . }}
+        release: {{ .Release.Name }}
+      annotations:
+        timestamp: "{{ date "20060102150405" .Release.Time }}"
+    spec:
+      containers:
+        - name: nginx
+          image: "{{ .Values.global.registry }}{{ .Values.redirects_stato_migrazione_anpr_it.images.nginx.repository }}:{{ tpl .Values.redirects_stato_migrazione_anpr_it.images.nginx.tag . }}"
+          imagePullPolicy: {{ .Values.redirects_stato_migrazione_anpr_it.images.nginx.pullPolicy }}
+
+          volumeMounts:
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d
+              readOnly: true
+
+          ports:
+            - name: http
+              containerPort: {{ .Values.redirects_stato_migrazione_anpr_it.services.nginx.httpPort.containerPort }}
+              protocol: {{ .Values.redirects_stato_migrazione_anpr_it.services.nginx.httpPort.protocol }}
+
+          resources:
+{{ toYaml .Values.redirects_stato_migrazione_anpr_it.resources.backend | indent 12 }}
+    {{- with .Values.redirects_stato_migrazione_anpr_it.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.redirects_stato_migrazione_anpr_it.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.redirects_stato_migrazione_anpr_it.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+
+      volumes:
+        - name: nginx-config
+          configMap:
+            name: {{ template "redirects-stato-migrazione-anpr-it.fullname" . }}-nginx-configmap

--- a/redirects-stato-migrazione-anpr-it/templates/ingress.yaml
+++ b/redirects-stato-migrazione-anpr-it/templates/ingress.yaml
@@ -1,0 +1,43 @@
+---
+
+{{- if .Values.redirects_stato_migrazione_anpr_it.ingress.enabled -}}
+{{- $fullName := include "redirects-stato-migrazione-anpr-it.fullname" . -}}
+{{- $servicePort := .Values.redirects_stato_migrazione_anpr_it.services.nginx.httpPort.servicePort -}}
+{{- $ingressPath := .Values.redirects_stato_migrazione_anpr_it.ingress.path -}}
+
+apiVersion: extensions/v1beta1
+
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app: {{ template "redirects-stato-migrazione-anpr-it.name" . }}
+    chart: {{ template "redirects-stato-migrazione-anpr-it.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.redirects_stato_migrazione_anpr_it.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.redirects_stato_migrazione_anpr_it.ingress.tls }}
+  tls:
+  {{- range .Values.redirects_stato_migrazione_anpr_it.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.redirects_stato_migrazione_anpr_it.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $servicePort }}
+  {{- end }}
+{{- end }}

--- a/redirects-stato-migrazione-anpr-it/templates/service.yaml
+++ b/redirects-stato-migrazione-anpr-it/templates/service.yaml
@@ -1,0 +1,20 @@
+---
+
+apiVersion: v1
+
+kind: Service
+metadata:
+  name: {{ template "redirects-stato-migrazione-anpr-it.fullname" . }}
+  labels:
+    app: {{ template "redirects-stato-migrazione-anpr-it.name" . }}
+    chart: {{ template "redirects-stato-migrazione-anpr-it.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.redirects_stato_migrazione_anpr_it.services.nginx.type }}
+  ports:
+    - port: {{ .Values.redirects_stato_migrazione_anpr_it.services.nginx.httpPort.servicePort }}
+      targetPort: {{ .Values.redirects_stato_migrazione_anpr_it.services.nginx.httpPort.containerPort }}
+  selector:
+    app: {{ template "redirects-stato-migrazione-anpr-it.name" . }}
+    release: {{ .Release.Name }}

--- a/redirects-stato-migrazione-anpr-it/values.yaml
+++ b/redirects-stato-migrazione-anpr-it/values.yaml
@@ -1,0 +1,62 @@
+---
+
+global:
+  registry: ''
+
+redirects_stato_migrazione_anpr_it:
+  images:
+    nginx:
+      repository: docker.io/nginx
+      tag: 1.20.0-alpine
+      pullPolicy: IfNotPresent
+
+  nginx_config: |
+    server {
+      listen 80;
+      listen [::]:80;
+      server_name stato-migrazione.anpr.it;
+
+      location / {
+        return 301 https://www.anpr.interno.it/AnprStatsWeb/;
+      }
+    }
+
+  services:
+    nginx:
+      httpPort:
+        servicePort: 80
+        containerPort: 80
+
+  ingress:
+    enabled: true
+    annotations:
+      kubernetes.io/ingress.class: nginx
+      kubernetes.io/tls-acme: "true"
+      nginx.ingress.kubernetes.io/ssl-redirect: "true"
+      cert-manager.io/cluster-issuer: letsencrypt-prod
+      cert-manager.io/acme-challenge-type: http01
+    path: /
+    hosts:
+      - stato-migrazione.anpr.it
+    tls:
+      - hosts:
+          - stato-migrazione.anpr.it
+        secretName: stato-migrazione-anpr-it-prod-tls
+
+  resources:
+    # For each of the following objects, set limits
+    # removing the curly brackets after resources and
+    # uncommenting the lines below.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+    nginx: {}
+
+  nodeSelector: {}
+
+  tolerations: {}
+
+  affinity: {}


### PR DESCRIPTION
https://stato-migrazione.anpr.it is now superceded by
https://www.anpr.interno.it/AnprStatsWeb/.

(on hold until we configure the DNS)