### PR TITLE
chore: add 10GiB to crawler-data PVC

### DIFF
--- a/storage/prod-pvc-crawler.yaml
+++ b/storage/prod-pvc-crawler.yaml
@@ -11,7 +11,7 @@ spec:
   storageClassName: managed-premium-custom
   resources:
     requests:
-      storage: 50Gi
+      storage: 60Gi
 
 ---
 


### PR DESCRIPTION
Add 10GiB to the crawler-data PVC as a quick fix to running low on
space.