### PR TITLE
chore: use the legacy version of developers-italia-backend

### DIFF
--- a/crawler/values.yaml
+++ b/crawler/values.yaml
@@ -7,7 +7,7 @@ crawler:
   images:
     crawler:
       repository: docker.io/italia/developers-italia-backend
-      tag: latest
+      tag: legacy
       pullPolicy: Always
     nginx:
       repository: docker.io/nginx


### PR DESCRIPTION
Use the legacy version of developers-italia-backend (the one NOT using the new APIs).

cc @tensor