### PR TITLE
fix: redirect Slack with HTTP 302

### DIFF
--- a/slack-registration/values.yaml
+++ b/slack-registration/values.yaml
@@ -21,7 +21,7 @@ slack_registration:
       }
 
       location / {
-        return 301 https://join.slack.com/t/developersitalia/shared_invite/zt-1m5lned7o-UbA55JWfbR08wgrqCtXQhA;
+        return 302 https://join.slack.com/t/developersitalia/shared_invite/zt-1m5lned7o-UbA55JWfbR08wgrqCtXQhA;
       }
     }
 


### PR DESCRIPTION
Use 302 for Slack redirection as the links will expire every 30 days or 400 uses.

cc @tensor5 