### PR TITLE
chore(elastic): set resource quota

### DIFF
--- a/elasticsearch/custom.yaml
+++ b/elasticsearch/custom.yaml
@@ -83,3 +83,11 @@ ingress:
     - hosts:
         - elasticsearch.developers.italia.it
       secretName: elasticsearch-prod-tls
+
+resources:
+  requests:
+    cpu: "500m"
+    memory: "2Gi"
+  limits:
+    cpu: "1000m"
+    memory: "2Gi"

--- a/kibana/custom.yaml
+++ b/kibana/custom.yaml
@@ -20,3 +20,11 @@ extraVolumes:
 extraVolumeMounts:
   - mountPath: /secrets-store
     name: secrets-store
+
+resources:
+  requests:
+    cpu: "200m"
+    memory: "1Gi"
+  limits:
+    cpu: "1000m"
+    memory: "2Gi"


### PR DESCRIPTION
By default the resource quota for Elasticsearch and Kibana is:

```yaml
resources:
  requests:
    cpu: "1000m"
    memory: "2Gi"
  limits:
    cpu: "1000m"
    memory: "2Gi"
```

however this value is over-estimated, and as stated in the [Usage note][1] it is important to "set the CPU/Memory resources to something suitable for your cluster".

The proposed new values are set empirically based on:

```yaml
$ kubectl top pods -n elasticsearch
NAME                                                 CPU(cores)   MEMORY(bytes)   
developersitalia-master-0                            36m          1394Mi          
developersitalia-master-1                            31m          1362Mi          
developersitalia-master-2                            26m          1447Mi          
kibana-kibana-6f75cbfc95-n7r55                       25m          296Mi           
prometheus-elasticsearch-exporter-6b56c66bc8-7gcvp   4m           21Mi            
```

[1]: https://artifacthub.io/packages/helm/elastic/elasticsearch#usage-notes