### PR TITLE
fix(developers-italia-api): always pull staging image

### DIFF
--- a/developers-italia-api/custom-staging.yaml
+++ b/developers-italia-api/custom-staging.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/italia/developers-italia-api
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
   tag: main
 
 deploymentAnnotations:


### PR DESCRIPTION
Always pull the staging image, as the ref never changes `main` and that makes k8s think that it has the image cached, even when it's not the latest.