### PR TITLE
chore(velero): update Azure plugin

### DIFF
--- a/system/prod-velero-custom.yaml
+++ b/system/prod-velero-custom.yaml
@@ -20,7 +20,7 @@ configuration:
 
 initContainers:
   - name: velero-plugin-for-microsoft-azure
-    image: velero/velero-plugin-for-microsoft-azure:v1.9.0
+    image: velero/velero-plugin-for-microsoft-azure:v1.9.2
     volumeMounts:
       - mountPath: /target
         name: plugins

--- a/system/prod-velero-custom.yaml
+++ b/system/prod-velero-custom.yaml
@@ -20,7 +20,7 @@ configuration:
 
 initContainers:
   - name: velero-plugin-for-microsoft-azure
-    image: velero/velero-plugin-for-microsoft-azure:v1.8.2
+    image: velero/velero-plugin-for-microsoft-azure:v1.9.0
     volumeMounts:
       - mountPath: /target
         name: plugins


### PR DESCRIPTION
Velero 1.13.x requires version 1.9.x of the plugin.